### PR TITLE
Reference delete when state is wrong and prevent possible segfaults.

### DIFF
--- a/daemon/docker.go
+++ b/daemon/docker.go
@@ -182,6 +182,21 @@ func (s *daemon) dockerMountVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if volume != nil{
+		attached, err := s.isVolumeAttached(volume.Name)
+		if err != nil || !attached{
+			log.Debugf("Volume %s is not attached to a device", volume.Name)
+			request := &api.VolumeDeleteRequest{
+				VolumeName: volume.Name,
+				ReferenceOnly: true,
+			}
+
+			// if a volume is not attached then processVolumeDelete() just updates the local state.
+			s.processVolumeDelete(request)
+			log.Debugf("Volume %s removed from local state", volume.Name)
+		}
+	}
+
 	if volume == nil {
 		if s.CreateOnDockerMount {
 			volume, err = s.createDockerVolume(request)

--- a/daemon/volume.go
+++ b/daemon/volume.go
@@ -57,6 +57,28 @@ func (s *daemon) volumeExists(name string) (bool, error) {
 	return false, nil
 }
 
+func (s *daemon) isVolumeAttached(name string) (bool, error) {
+	for _, driver := range s.ConvoyDrivers {
+		volOps, err := driver.VolumeOps()
+		if err != nil {
+			return false, err
+		}
+
+		v, err := volOps.GetVolumeInfo(name)
+		if err != nil {
+			if util.IsNotExistsError(err) {
+				continue
+			}
+			return false, err
+		}
+
+		if v["AWSMountPoint"] != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *daemon) generateName() (string, error) {
 	name := util.GenerateName("volume")
 	for {


### PR DESCRIPTION
Before this the volume mount would fail when convoy thinks there is
a volume json file in the driver state but it was probably detached
by bypassing convoy in the past, thus not updating the state.

Now it updates the state by deleting the volume.

Also use `aws.StringValue(s *string)` since just dereferencing a
pointer without it can cause a segmentation fault.
