### PR TITLE
Create filesystem if missing

### DIFF
--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -37,6 +37,8 @@ Other values are st1 and sc1.
 Default is blank, if specified then volumes will be encrypted using the given kms key id.
 #### `ebs.defaultencrypted`
 `false` by default, if `true` then volumes will be encrypted with the default account kms key.
+#### `ebs.defaultfilesystem`
+`ext4` by default, supported options are "btrfs", "ext2", "ext3", "ext4", "minix", or "xfs".
 
 ## Command details
 ### `create`

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -33,11 +33,12 @@ const (
 	EBS_CLUSTER_NAME = "ebs.clustername"
 	EBS_DEFAULT_VOLUME_KEY  = "ebs.defaultkmskeyid"
 	EBS_DEFAULT_ENCRYPTED   = "ebs.defaultencrypted"
+	EBS_DEFAULT_FILESYSTEM  = "ebs.defaultfilesystem"
 
 	DEFAULT_VOLUME_SIZE = "4G"
 	DEFAULT_VOLUME_TYPE = "gp2"
 	DEFAULT_CLUSTER_NAME = ""
-	FILESYSTEM_NEEDED_TAG = "NeedFS"
+	DEFAULT_FILESYSTEM   = "ext4"
 
 	MOUNTS_DIR    = "mounts"
 	MOUNT_BINARY  = "mount"
@@ -55,6 +56,7 @@ type Device struct {
 	DefaultVolumeSize int64
 	DefaultVolumeType string
 	DefaultDCName     string
+	DefaultFSType     string
 	DefaultKmsKeyID   string
 	DefaultEncrypted  bool
 }
@@ -197,6 +199,12 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 		}
 		log.Debugf("Setting DC name in driver as %s", config[EBS_CLUSTER_NAME])
 		dcName := config[EBS_CLUSTER_NAME]
+		if config[EBS_DEFAULT_FILESYSTEM] == "" {
+			config[EBS_DEFAULT_FILESYSTEM] = DEFAULT_FILESYSTEM
+		} else {
+			log.Debugf("Setting default filesystem type in driver to %q", config[EBS_DEFAULT_FILESYSTEM])
+		}
+		fsType := config[EBS_DEFAULT_FILESYSTEM]
 		kmsKeyId := config[EBS_DEFAULT_VOLUME_KEY]
 		var encrypted bool
 		if encryptedStr, ok := config[EBS_DEFAULT_ENCRYPTED]; ok {
@@ -209,6 +217,7 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 			DefaultVolumeSize: size,
 			DefaultVolumeType: volumeType,
 			DefaultDCName: dcName,
+			DefaultFSType:     fsType,
 			DefaultKmsKeyID:   kmsKeyId,
 			DefaultEncrypted:  encrypted,
 		}
@@ -237,6 +246,7 @@ func (d *Driver) Info() (map[string]string, error) {
 	infos["DefaultVolumeSize"] = strconv.FormatInt(d.DefaultVolumeSize, 10)
 	infos["DefaultVolumeType"] = d.DefaultVolumeType
 	infos["DefaultKmsKey"] = d.DefaultKmsKeyID
+	infos["DefaultFSType"] = d.DefaultFSType
 	infos["DefaultEncrypted"] = fmt.Sprint(d.DefaultEncrypted)
 	infos["InstanceID"] = d.ebsService.InstanceID
 	infos["Region"] = d.ebsService.Region
@@ -287,7 +297,7 @@ func (d *Driver) CreateVolume(req Request) error {
 	var (
 		err        error
 		volumeSize int64
-		format     bool
+		needsFS    bool
 	)
 
 	d.mutex.Lock()
@@ -417,7 +427,7 @@ func (d *Driver) CreateVolume(req Request) error {
 			return err
 		}
 		log.Debugf("Created volume %s from EBS volume %v", id, volumeID)
-		format = true
+		needsFS = true
 	}
 
 	dev, err := d.ebsService.AttachVolume(volumeID, volumeSize)
@@ -431,8 +441,7 @@ func (d *Driver) CreateVolume(req Request) error {
 	volume.Device = dev
 	volume.Snapshots = make(map[string]Snapshot)
 
-	var needsFS bool
-	if !format {
+	if !needsFS {
 		if fsType, err := fs.Detect(volume.Device); err != nil {
 			if err == fs.ErrNoFilesystemDetected {
 				needsFS = true
@@ -444,9 +453,9 @@ func (d *Driver) CreateVolume(req Request) error {
 		}
 	}
 
-	if format || needsFS {
-		log.Debugf("Formatting device=%s", volume.Device)
-		if err := fs.FormatDevice(volume.Device, "ext4"); err != nil {
+	if needsFS {
+		log.Debugf("Formatting device=%s with filesystem type=%s", volume.Device, d.DefaultFSType)
+		if err := fs.FormatDevice(volume.Device, d.DefaultFSType); err != nil {
 			return err
 		}
 	}

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/rancher/convoy/util"
-
 	. "github.com/rancher/convoy/convoydriver"
 	. "github.com/rancher/convoy/logging"
+	"github.com/rancher/convoy/util"
+	"github.com/rancher/convoy/util/fs"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -430,45 +431,31 @@ func (d *Driver) CreateVolume(req Request) error {
 	volume.Device = dev
 	volume.Snapshots = make(map[string]Snapshot)
 
-	// We don't format existing or snapshot restored volume
-	if format || d.volumeNeedsFS(volume) {
-		if _, err := util.Execute("mkfs", []string{"-t", "ext4", dev}); err != nil {
-			return err
+	var needsFS bool
+	if !format {
+		if fsType, err := fs.Detect(volume.Device); err != nil {
+			if err == fs.ErrNoFilesystemDetected {
+				needsFS = true
+			} else {
+				return err
+			}
+		} else {
+			log.Debugf("Detected existing filesystem type=%s for device=%s", fsType, volume.Device)
 		}
-		if err := d.setVolumeHasFS(volume); err != nil {
+	}
+
+	if format || needsFS {
+		log.Debugf("Formatting device=%s", volume.Device)
+		if err := fs.FormatDevice(volume.Device, "ext4"); err != nil {
 			return err
 		}
 	}
 
-	return util.ObjectSave(volume)
-}
-
-// setVolumeHasFS removes the Tag 'needsFS:true' indicating the volume already has a filesystem.
-func (d *Driver) setVolumeHasFS(volume *Volume) error {
-	needFsTag := make(map[string]string)
-	needFsTag[FILESYSTEM_NEEDED_TAG] = "true"
-	if err := d.ebsService.DeleteTags(volume.EBSID, needFsTag); err != nil {
-		log.Errorf("Unable to delete Tag %v in volume %v(%v).", FILESYSTEM_NEEDED_TAG, volume.Name, volume.EBSID)
+	if err := util.ObjectSave(volume); err != nil {
 		return err
 	}
-	return nil
-}
 
-// volumeNeedsFs tells if the given volume has a Tag 'needFS:true', indicating it needs to be formated. */
-func (d *Driver) volumeNeedsFS(volume *Volume) bool {
-	tags, err := d.ebsService.GetTags(volume.EBSID)
-	if err != nil {
-		log.Debugf("Unable to determine if volume %v needs a Fs. Can't fetch tags for volume %v(%v)", volume.Name, volume.EBSID)
-		return false
-	}
-	needFs := tags[FILESYSTEM_NEEDED_TAG] != ""
-	if needFs {
-		log.Debugf("Tag %v found in %v(%v), %v needs a filesystem.", FILESYSTEM_NEEDED_TAG,
-			volume.Name, volume.EBSID, volume.Device)
-	} else {
-		log.Debugf("Tag '%v' not present in %v(%v).", volume.Name, volume.EBSID, FILESYSTEM_NEEDED_TAG)
-	}
-	return needFs
+	return nil
 }
 
 func (d *Driver) DeleteVolume(req Request) error {

--- a/util/fs/fs.go
+++ b/util/fs/fs.go
@@ -1,0 +1,40 @@
+package fs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+var ErrNoFilesystemDetected = errors.New("no filesystem detected")
+
+func FormatDevice(devicePath string, fsType string) error {
+	switch fsType {
+	case "btrfs", "ext2", "ext3", "ext4", "minix", "xfs":
+	default:
+		return fmt.Errorf("unrecognized or unsupported fs-type: %s", fsType)
+	}
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("yes | sudo -n mkfs.%s %s", fsType, devicePath))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("FormatDevice: %s: %s", string(output), err)
+	}
+	return nil
+}
+
+// Detect determines the filesystem type for the given device.
+// An empty-string return indicates an unformatted device.
+func Detect(devicePath string) (string, error) {
+	cmd := exec.Command("sudo", "-n", "blkid", "-s", "TYPE", "-o", "value", devicePath)
+	output, err := cmd.CombinedOutput()
+	output = bytes.Trim(output, "\r\n \t")
+	if err != nil {
+		if len(output) == 0 && err.Error() == "exit status 2" {
+			// Then no filesystem detected.
+			return "", ErrNoFilesystemDetected
+		}
+		return "", fmt.Errorf("Detect: %s: %s", string(output), err)
+	}
+	fsType := string(output)
+	return fsType, nil
+}

--- a/util/fs/fs_test.go
+++ b/util/fs/fs_test.go
@@ -1,0 +1,116 @@
+package fs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+var supportedFsTypes = []string{"btrfs", "ext2", "ext3", "ext4", "minix", "xfs"}
+
+func TestDeviceFormatter(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("TestDeviceFormatter skipped because OS is not 'linux'")
+	}
+	if !hasPasswordlessSudo() {
+		t.Skip("TestDeviceFormatter skipped because password-less sudo is required and not presently available")
+	}
+
+	for _, targetFsType := range supportedFsTypes {
+		func() {
+			// Create fake device.
+			fakeDevicePath := fmt.Sprintf("/tmp/TestDeviceFormatter-%s.img", targetFsType)
+			if err := makeFakeDevice(fakeDevicePath); err != nil {
+				t.Fatal(err)
+			}
+
+			// Cleanup and remove it afterwards.
+			defer func() {
+				if err := os.RemoveAll(fakeDevicePath); err != nil {
+					t.Error(err.Error())
+				}
+			}()
+
+			// Unformatted case.
+			if fsType, err := Detect(fakeDevicePath); err == nil {
+				t.Fatalf("Expected non-nil error from Detect for unformatted device, but got fsType=%s err=%+v", fsType, err)
+			}
+
+			// Format it.
+			if err := FormatDevice(fakeDevicePath, targetFsType); err != nil {
+				t.Fatalf("Unexpected error formatting device=%s: %s", fakeDevicePath, err)
+			}
+		}()
+	}
+}
+
+func TestFSDetector(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("TestFSDetector skipped because OS is not 'linux'")
+	}
+	if !hasPasswordlessSudo() {
+		t.Skip("TestFSDetector skipped because password-less sudo is required and not presently available")
+	}
+
+	// Non-existent test case.
+	if fsType, err := Detect("/TestFSDetector/foo/bar/baz"); err != ErrNoFilesystemDetected {
+		t.Errorf("Expected ErrNoFilesystemDetected error from Detect, but got result fsType=%s err=%+v", fsType, err)
+	}
+
+	for _, targetFsType := range supportedFsTypes {
+		func() {
+			// Create fake device.
+			fakeDevicePath := fmt.Sprintf("/tmp/TestFSDetector-%s.img", targetFsType)
+			if err := makeFakeDevice(fakeDevicePath); err != nil {
+				t.Fatal(err)
+			}
+
+			// Cleanup and remove it afterwards.
+			defer func() {
+				if err := os.RemoveAll(fakeDevicePath); err != nil {
+					t.Error(err.Error())
+				}
+			}()
+
+			// Unformatted case.
+			if fsType, err := Detect(fakeDevicePath); err != ErrNoFilesystemDetected {
+				t.Fatalf("Expected ErrNoFilesystemDetected from Detect for unformatted device, but got fsType=%s err=%+v", fsType, err)
+			}
+
+			// Format it.
+			if err := FormatDevice(fakeDevicePath, targetFsType); err != nil {
+				t.Fatalf("Unexpected error formatting device=%s: %s", fakeDevicePath, err)
+			}
+
+			// Formatted case.
+			{
+				fsType, err := Detect(fakeDevicePath)
+				if err != nil {
+					t.Errorf("Unexpected error from Detect: %s", err)
+				}
+				if expected, actual := targetFsType, fsType; actual != expected {
+					t.Errorf("Wrong result from Detect, expected fsType=%q but actual=%q", expected, actual)
+				}
+			}
+		}()
+	}
+}
+
+func makeFakeDevice(path string) error {
+	size := 100 // NB: btrfs requires a minimum size of 100MB.
+	if output, err := exec.Command("dd", "if=/dev/zero", fmt.Sprintf("of=%s", path), "bs=1M", fmt.Sprintf("count=%v", size)).CombinedOutput(); err != nil {
+		return fmt.Errorf("fake device setup failed: dd command output=%s err=%s", string(bytes.Trim(output, "\r\n \t")), err)
+	}
+	return nil
+}
+
+func hasPasswordlessSudo() bool {
+	cmd := exec.Command("sudo", "-n", "true")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
[https://jira.medallia.com/browse/CLOUD-264](CLOUD-264)

"When a new volume is attached, if it does not have a file system specified, create one. This makes the need use the tag introduced in a7f0dd87fce35026496715e0a9d1b8fb0a6c11e3 un-necessary"