### PR TITLE
CLOUD-282 Resize device file system

### DIFF
--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -39,6 +39,10 @@ Default is blank, if specified then volumes will be encrypted using the given km
 `false` by default, if `true` then volumes will be encrypted with the default account kms key.
 #### `ebs.defaultfilesystem`
 `ext4` by default, supported options are "btrfs", "ext2", "ext3", "ext4", "minix", or "xfs".
+#### `ebs.autoformat`
+`true` by default. Decides whether convoy should format a filesystem on the device which doesn't have one already. If set, it will use the fs type set in `ebs.defaultfilesystem`
+#### `ebs.autoresizefs`
+`true` by default. If set to `true` then Convoy runs a redundant `resize2fs` on a device if it finds a filesystem on it. This is helpful to sync the filesystem in scenarios where your block devices might get resized in the backend.
 
 ## Command details
 ### `create`

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -606,20 +606,18 @@ func (d *Driver) CreateVolume(req Request) error {
 			log.Debugf("Detected existing filesystem type=%s for device=%s", fsType, volume.Device)
 			if d.AutoResizeFS {
 				log.Debugf("Ensuring filesystem size and device's (%s) size are in sync.", volume.Device)
-				if er := fs.Resize(volume.Device); er != nil {
-					log.Debugf("Error in syncing sizes %s", volume.Device)
-					return er
+				if err := fs.Resize(volume.Device); err != nil {
+					log.Debugf("Error in syncing sizes %s: %s", volume.Device, err.Error())
+					return err
 				}
 			}
 		}
 	}
 
-	if needsFS {
-		if d.AutoFormat {
-			log.Debugf("Formatting device=%s with filesystem type=%s", volume.Device, d.DefaultFSType)
-			if err := fs.FormatDevice(volume.Device, d.DefaultFSType); err != nil {
-				return err
-			}
+	if needsFS && d.AutoFormat{
+		log.Debugf("Formatting device=%s with filesystem type=%s", volume.Device, d.DefaultFSType)
+		if err := fs.FormatDevice(volume.Device, d.DefaultFSType); err != nil {
+			return err
 		}
 	}
 

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -581,6 +581,11 @@ func (d *Driver) CreateVolume(req Request) error {
 			}
 		} else {
 			log.Debugf("Detected existing filesystem type=%s for device=%s", fsType, volume.Device)
+			log.Debugf("Ensuring filesystem size and device's (%s) size are in sync.", volume.Device)
+			if er := fs.Resize(volume.Device); er != nil{
+				log.Debugf("Error in syncing sizes %s", volume.Device)
+				return er
+			}
 		}
 	}
 

--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -239,6 +239,7 @@ func Init(root string, config map[string]string) (ConvoyDriver, error) {
 				return nil, err
 			}
 		}
+		log.Debugf("Setting 2 flags autoFormat:%v autoResizefs:%v", autoFormat, autoResizefs)
 
 		dev = &Device{
 			Root:              root,
@@ -281,8 +282,8 @@ func (d *Driver) Info() (map[string]string, error) {
 	infos["InstanceID"] = d.ebsService.InstanceID
 	infos["Region"] = d.ebsService.Region
 	infos["AvailiablityZone"] = d.ebsService.AvailabilityZone
-	infos["AutoResizeFS"] = d.AutoResizeFS
-	infos["AutoFormat"] = d.AutoFormat
+	infos["AutoResizeFS"] = fmt.Sprint(d.AutoResizeFS)
+	infos["AutoFormat"] = fmt.Sprint(d.AutoFormat)
 	return infos, nil
 }
 

--- a/util/fs/fs.go
+++ b/util/fs/fs.go
@@ -38,3 +38,16 @@ func Detect(devicePath string) (string, error) {
 	fsType := string(output)
 	return fsType, nil
 }
+
+// Resize a device path by calling resize2fs on it. In case of success,
+// resize2fs only runs a resize when it is
+// required on the device; otherwise, it just exits with a code 0 and a message.
+func Resize(devicePath string) error {
+	cmd := exec.Command("sudo", "-n", "resize2fs", devicePath)
+	output, err := cmd.CombinedOutput()
+	output = bytes.Trim(output, "\r\n \t")
+	if err != nil {
+		return fmt.Errorf("Resize: %s: %s", devicePath, string(output))
+	}
+	return nil
+}

--- a/util/fs/fs.go
+++ b/util/fs/fs.go
@@ -43,7 +43,7 @@ func Detect(devicePath string) (string, error) {
 // resize2fs only runs a resize when it is
 // required on the device; otherwise, it just exits with a code 0 and a message.
 func Resize(devicePath string) error {
-	cmd := exec.Command("sudo", "-n", "resize2fs", devicePath)
+	cmd := exec.Command("sudo", "-n", "resize2fs", "-f", devicePath)
 	output, err := cmd.CombinedOutput()
 	output = bytes.Trim(output, "\r\n \t")
 	if err != nil {

--- a/util/fs/fs_test.go
+++ b/util/fs/fs_test.go
@@ -47,23 +47,28 @@ func TestDeviceFormatter(t *testing.T) {
 	}
 }
 
-func TestFSDetector(t *testing.T) {
+func TestFSDetectorResize(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("TestFSDetector skipped because OS is not 'linux'")
+		t.Skip("TestFSDetectorResize skipped because OS is not 'linux'")
 	}
 	if !hasPasswordlessSudo() {
-		t.Skip("TestFSDetector skipped because password-less sudo is required and not presently available")
+		t.Skip("TestFSDetectorResize skipped because password-less sudo is required and not presently available")
 	}
 
 	// Non-existent test case.
-	if fsType, err := Detect("/TestFSDetector/foo/bar/baz"); err != ErrNoFilesystemDetected {
+	if fsType, err := Detect("/TestFSDetectorResize/foo/bar/baz"); err != ErrNoFilesystemDetected {
 		t.Errorf("Expected ErrNoFilesystemDetected error from Detect, but got result fsType=%s err=%+v", fsType, err)
+	}
+
+	// Non-existent test case.
+	if err := Resize("/TestFSDetectorResize/foo/bar/baz"); err == nil  {
+		t.Error("Expected error from Resize, but got nothing")
 	}
 
 	for _, targetFsType := range supportedFsTypes {
 		func() {
 			// Create fake device.
-			fakeDevicePath := fmt.Sprintf("/tmp/TestFSDetector-%s.img", targetFsType)
+			fakeDevicePath := fmt.Sprintf("/tmp/TestFSDetectorResize-%s.img", targetFsType)
 			if err := makeFakeDevice(fakeDevicePath); err != nil {
 				t.Fatal(err)
 			}
@@ -80,6 +85,11 @@ func TestFSDetector(t *testing.T) {
 				t.Fatalf("Expected ErrNoFilesystemDetected from Detect for unformatted device, but got fsType=%s err=%+v", fsType, err)
 			}
 
+			// Unformatted case.
+			if err := Resize(fakeDevicePath); err == nil {
+				t.Fatal("Expected error from Resize for unformatted device, but got nothing")
+			}
+
 			// Format it.
 			if err := FormatDevice(fakeDevicePath, targetFsType); err != nil {
 				t.Fatalf("Unexpected error formatting device=%s: %s", fakeDevicePath, err)
@@ -94,60 +104,16 @@ func TestFSDetector(t *testing.T) {
 				if expected, actual := targetFsType, fsType; actual != expected {
 					t.Errorf("Wrong result from Detect, expected fsType=%q but actual=%q", expected, actual)
 				}
-			}
-		}()
-	}
-}
 
-
-func TestResize(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("TestFSDetector skipped because OS is not 'linux'")
-	}
-	if !hasPasswordlessSudo() {
-		t.Skip("TestFSDetector skipped because password-less sudo is required and not presently available")
-	}
-
-	// Non-existent test case.
-	if err := Resize("/TestFSDetector/foo/bar/baz"); err == nil  {
-		t.Errorf("Expected error from Resize, but got nothing")
-	}
-
-	for _, targetFsType := range supportedFsTypes {
-		func() {
-			// Create fake device.
-			fakeDevicePath := fmt.Sprintf("/tmp/TestFSDetector-%s.img", targetFsType)
-			if err := makeFakeDevice(fakeDevicePath); err != nil {
-				t.Fatal(err)
-			}
-
-			// Cleanup and remove it afterwards.
-			defer func() {
-				if err := os.RemoveAll(fakeDevicePath); err != nil {
-					t.Error(err.Error())
-				}
-			}()
-
-			// Unformatted case.
-			if err := Resize(fakeDevicePath); err == nil {
-				t.Fatalf("Expected error from Resize for unformatted device, but got nothing")
-			}
-
-			// Format it.
-			if err := FormatDevice(fakeDevicePath, targetFsType); err != nil {
-				t.Fatalf("Unexpected error formatting device=%s: %s", fakeDevicePath, err)
-			}
-
-			// Formatted case.
-			{
-				err := Resize(fakeDevicePath)
+				err = Resize(fakeDevicePath)
 				if err != nil {
-					t.Errorf("Unexpected error: %s", err)
+					t.Errorf("Unexpected error in resize: %s", err)
 				}
 			}
 		}()
 	}
 }
+
 
 func makeFakeDevice(path string) error {
 	size := 100 // NB: btrfs requires a minimum size of 100MB.

--- a/util/fs/fs_test.go
+++ b/util/fs/fs_test.go
@@ -99,6 +99,56 @@ func TestFSDetector(t *testing.T) {
 	}
 }
 
+
+func TestResize(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("TestFSDetector skipped because OS is not 'linux'")
+	}
+	if !hasPasswordlessSudo() {
+		t.Skip("TestFSDetector skipped because password-less sudo is required and not presently available")
+	}
+
+	// Non-existent test case.
+	if err := Resize("/TestFSDetector/foo/bar/baz"); err == nil  {
+		t.Errorf("Expected error from Resize, but got nothing")
+	}
+
+	for _, targetFsType := range supportedFsTypes {
+		func() {
+			// Create fake device.
+			fakeDevicePath := fmt.Sprintf("/tmp/TestFSDetector-%s.img", targetFsType)
+			if err := makeFakeDevice(fakeDevicePath); err != nil {
+				t.Fatal(err)
+			}
+
+			// Cleanup and remove it afterwards.
+			defer func() {
+				if err := os.RemoveAll(fakeDevicePath); err != nil {
+					t.Error(err.Error())
+				}
+			}()
+
+			// Unformatted case.
+			if err := Resize(fakeDevicePath); err == nil {
+				t.Fatalf("Expected error from Resize for unformatted device, but got nothing")
+			}
+
+			// Format it.
+			if err := FormatDevice(fakeDevicePath, targetFsType); err != nil {
+				t.Fatalf("Unexpected error formatting device=%s: %s", fakeDevicePath, err)
+			}
+
+			// Formatted case.
+			{
+				err := Resize(fakeDevicePath)
+				if err != nil {
+					t.Errorf("Unexpected error: %s", err)
+				}
+			}
+		}()
+	}
+}
+
 func makeFakeDevice(path string) error {
 	size := 100 // NB: btrfs requires a minimum size of 100MB.
 	if output, err := exec.Command("dd", "if=/dev/zero", fmt.Sprintf("of=%s", path), "bs=1M", fmt.Sprintf("count=%v", size)).CombinedOutput(); err != nil {


### PR DESCRIPTION
Add auto-resize for filesystem functionality to Convoy.

Gate the functionality with `ebs.autoresizefs=true` toggle flag.

Also backport a `ebs.autoformat=true` toggle flag for auto FS formatting.