### PR TITLE
CLOUD-298 Convoy should infer volume size from name

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -236,7 +236,7 @@ func DetachAnyLoopbackDevice(file string) error {
 }
 
 func ValidateName(name string) bool {
-	validName := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+	validName := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9_.-]|@)+$`)
 	return validName.MatchString(name)
 }
 


### PR DESCRIPTION
This commit enables convoy to read the volume name and create
the volume as the expected default behavior, but also scan the
name for `@XG` appended to the name where XG is size in gigabytes.

The volume is created of this specific size, while this data is
consumed by convoy and not passed forward so that we leave no traces 
of it in the backend. This makes this change backwards compatible as 
well as easy to deprecate in the future.