### PR TITLE
CLOUD-320 Convoy drivers should get their own error type.

### DIFF
--- a/util/errors.go
+++ b/util/errors.go
@@ -1,0 +1,35 @@
+package util
+
+//error types
+const (
+	ErrVolumeNotFoundCode = iota
+	ErrSnapshotNotFoundCode
+	ErrVolumeInUseCode
+	ErrVolumeExistsCode
+	ErrVolumeNotAvailableCode
+	ErrVolumeCreateFailureCode
+	ErrVolumeDeleteFailureCode
+	ErrVolumeAttachFailureCode
+	ErrVolumeDetachFailureCode
+	ErrDeviceFailureCode
+	ErrVolumeTransitionCode
+	ErrInvalidRequestCode
+	ErrGenericFailureCode //prefer if no other error type suffices
+)
+
+type ConvoyDriverErr struct {
+	//Original error from the backend
+	Err error
+
+	//Convoy's internal error code
+	ErrorCode int
+}
+
+func (e ConvoyDriverErr) Error() string {
+	return e.Err.Error()
+}
+
+//GetConvoyErr returns a ConvoyErr which contains the original error and a suitable error code
+func NewConvoyDriverErr(err error, errCode int) error {
+	return &ConvoyDriverErr{Err: err, ErrorCode: errCode}
+}


### PR DESCRIPTION
This introduces the ConvoyErr type that satisfies the error
interface and also adds an error code to the errors for
middleware error handling logic. The error codes do not replicate
back end responses but act as a facade. Also fixes CLOUD-319.