### PR TITLE
Strict consistency of `k=v' style logging in EBS package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ _testmain.go
 *.prof
 
 longhorn/template.go
+
+/.dapper


### PR DESCRIPTION
Strict consistency of `k=v' style logging in EBS package.

* Also added ".dapper" build artifact to .gitignore.
