### PR TITLE
Removed use of `os/user' in `util/fs' due to incompatibility with ldflags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ _testmain.go
 longhorn/template.go
 
 /.dapper
+
+/bin/convoy

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,10 @@
 #!/bin/bash
-set -e
 
-cd $(dirname $0)/..
+set -o errexit
+set -o pipefail
+set -o nounset
+
+cd "$(dirname $0)"/..
 
 echo Running tests
 
@@ -11,4 +14,4 @@ fi
 
 PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
-go test -race -cover -tags "libdm_no_deferred_remove s3test" ${PACKAGES}
+go test -race -cover -tags "libdm_no_deferred_remove s3test" -ldflags "-linkmode external -extldflags -static" ${PACKAGES}

--- a/util/fs/fs.go
+++ b/util/fs/fs.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"os/user"
+	"strings"
 )
 
 var (
@@ -90,11 +90,11 @@ func sudoCmd(name string, args ...string) (*exec.Cmd, error) {
 // sudoCmdPrefix accounts for sudo only being necessary when UID != 0 (i.e. when not
 // root).
 func sudoCmdPrefix() ([]string, error) {
-	u, err := user.Current()
+	uid, err := exec.Command("id", "--user").Output()
 	if err != nil {
 		return nil, err
 	}
-	if u.Uid != "0" {
+	if strings.Trim(string(uid), "\n") != "0" {
 		return []string{"sudo", "-n"}, nil
 	}
 	return nil, nil


### PR DESCRIPTION
Removed use of `os/user' in `util/fs' due to incompatibility with ldflags.

- Panics observed in `C' package and documented in
  [CLOUD-412](https://jira.medallia.com/browse/CLOUD-412).

  This is a case of static-linker issues, and not easily reproducible.

  The offending code has been added to the `test` script to ensure this
  problem can be caught by CI in the future.

  Snippet related to static linker:

    `-ldflags "-linkmode external -extldflags -static"`