### PR TITLE
Apply default FS on an empty string and not 'nil'

### DIFF
--- a/ebs/ebs.go
+++ b/ebs/ebs.go
@@ -751,9 +751,13 @@ func (d *Driver) CreateVolume(req Request) error {
 		}
 	}
 
-	fsType := d.DefaultFSType
-	if typ, ok := opts[OPT_VOLUME_FS_TYPE]; ok {
-		fsType = typ
+	//EBS Volume FS type
+	fsType := opts[OPT_VOLUME_FS_TYPE]
+	if fsType == "" {
+		log.Debugf("FS type not specified in request, setting to default=%v", d.DefaultFSType)
+		fsType = d.DefaultFSType
+	} else {
+		log.Debugf("Found FS type=%v in request", fsType)
 	}
 	if needsFS && d.AutoFormat {
 		log.Debugf("Formatting device=%v with filesystem type=%v", volume.Device, fsType)


### PR DESCRIPTION
Follow the same logic we use for setting volume IDs and
volume names earlier in the method for consistency.

The current way of doing it causes new volumes to break since 
we need to check for empty string not nil